### PR TITLE
Explicit `vote_value` to represent `Abstain`

### DIFF
--- a/EEPS/eep-4.md
+++ b/EEPS/eep-4.md
@@ -33,10 +33,10 @@ that was available on the EOS mainnet. Namely, there was need to add definition 
 
 ### General Behaviour/Definitions (Apply to all proposal types)
 
-Any `vote_value` that is submitted that does not fall into the expected results will be only be used to count
-towards voter participation of the overall vote (if that metric is being observed). For example, for proposal type
-`referendum-v1`, a `vote_value` of `7` shall not count towards `No` or `Yes`, but the staked amount will count towards
-voter participation for the "15% voter participation threshold".
+A `vote_value` of `255` will represent an `Abstain` vote.
+An `Abstain` vote will count towards voter participation of the overall vote (if that metric is being observed). 
+For example, for proposal type `referendum-v1`, a `vote_value` of `255` shall not count towards `No` or `Yes`, but the staked amount will count towards voter participation for the "15% voter participation threshold".
+Any submitted `vote_value` that does not fall into any of the expected results will be ignored. 
 
 Votes are weighted using information from the `staked` table for voter info. If a user has not voted, then the weight
 of their vote will be taken from the `delband` table. To clarify, a voter's weight should be equal to their self-staked
@@ -51,8 +51,8 @@ chosen `vote_value` on its own.
 ### Referendum
 
 `referendum-v1` should be seen as the only `type` that Block Producers should utilize as a signal 
-to act upon. The available responses are always `0`:`No`, `1`:`Yes`
-All UIs should display the voting buttons along with their value e.g. "0 - No" and "1 - Yes"
+to act upon. The available responses are always `0`:`No`, `1`:`Yes`, `255`:`Abstain`
+UIs can display the voting buttons along with their value e.g. "0 - No", "1 - Yes" and "255 - Abstain"
 so that a user can easily verify their vote through any block explorer, without the need to already
 have the knowledge that a `vote_value` of 0 properly signifies their vote of "No", and so on.
 
@@ -77,6 +77,8 @@ Standard `vote_value`:
 `0` - "No" 
 
 `1` - "Yes" 
+
+`255` - "Abstain" 
 
 If a vote of `type`:`referendum-v1` passes the required thresholds as defined in the goverenance documents,
 Block Producers should act upon the result of this referendum.
@@ -138,8 +140,8 @@ being proposed for a `referendum`.
 
 `poll-yna-v1` should be used for any polling that uses only Yes/No/Abstain responses, and 
 is not being proposed as an actionable vote for Block Producers. This should only be used for polling sentiment.
-The available responses are always `0`:`No`, `1`:`Yes`, `2`:`Abstain`
-All UIs should display the voting buttons along with their value e.g. "0 - No", "1 - Yes", and "2 - Abstain"
+The available responses are always `0`:`No`, `1`:`Yes`, `255`:`Abstain`
+UIs can display the voting buttons along with their value e.g. "0 - No", "1 - Yes", and "255 - Abstain"
 so that a user can easily verify their vote through any block explorer, without the need to already
 have the knowledge that a `vote_value` of 0 properly signifies their vote of "No", and so on.
 
@@ -168,7 +170,7 @@ Standard `vote_value`:
 
 `1` - "Yes" 
 
-`2` - "Abstain"
+`255` - "Abstain"
 
 As this `type` of poll is not used for an official chain-altering decision, Block Producers
 should **not** act in any meaningful way to the results of these polls. This can be useful for 
@@ -183,9 +185,9 @@ referendum, and whether or not it might receive enough voter participation.
 ### Options Poll
 
 `options-v1` should be used for any polling that requires multiple custom responses (`proposer` can
-specify up to 255 different responses. It is encouraged to always provide one option for `Abstain`). 
-UIs should fetch the possible responses from the "options" array. All UIs should push a vote value 
-equal to the positon of the repsonse in the table (0-indexed), and should display the button as 
+specify up to 254 different responses, and reserve `vote_value` of `255` for "Abstain"). 
+UIs should fetch the possible responses from the "options" array. UIs should push a vote value 
+equal to the positon of the repsonse in the table (0-indexed). You can display the button as 
 "`value` - `response`" so that a user can easily verify their vote through any block explorer, while 
 lowering the amount of RAM needed to vote.
 
@@ -235,6 +237,8 @@ bits available, a value of `0` will  signify "unselected" and a value of `1` wil
 With up to 8 responses available, each bit will correspond to its index in the array (0-indexed), in 
 big-endian form, highest index being the most significant bit in the final value.
 
+A `vote_value` of `255` shall represent `Abstain`
+
 ```
 {
   "type":"multi-select-v1",
@@ -271,6 +275,8 @@ represented as `00110001`. When converted to decimal, this will be represented b
 There are no standard `options` defined for this `type`. Options are all `proposer`-defined.
 Each `vote_value` pushed to chain should be broken down from their decimal representation to their
 binary representation. `0` will signify all unselected responses, while `1` will signify all selected responses. 
+
+A `vote_value` of `255` represents `Abstain` for consistency across all proposal types (despite 0 being the natural result from the binary conversion)
 
 ## References
 

--- a/EEPS/eep-4.md
+++ b/EEPS/eep-4.md
@@ -33,7 +33,7 @@ that was available on the EOS mainnet. Namely, there was need to add definition 
 
 ### General Behaviour/Definitions (Apply to all proposal types)
 
-A `vote_value` of `255` will represent an `Abstain` vote.
+A `vote_value` of `255` will represent an `Abstain` vote, except for `multiselect-v` which wil utilize a `vote_value` of `0` to represent `Abstain`.
 An `Abstain` vote will count towards voter participation of the overall vote (if that metric is being observed). 
 For example, for proposal type `referendum-v1`, a `vote_value` of `255` shall not count towards `No` or `Yes`, but the staked amount will count towards voter participation for the "15% voter participation threshold".
 Any submitted `vote_value` that does not fall into any of the expected results will be ignored. 
@@ -237,7 +237,7 @@ bits available, a value of `0` will  signify "unselected" and a value of `1` wil
 With up to 8 responses available, each bit will correspond to its index in the array (0-indexed), in 
 big-endian form, highest index being the most significant bit in the final value.
 
-A `vote_value` of `255` shall represent `Abstain`
+A `vote_value` of `0` shall represent `Abstain`
 
 ```
 {
@@ -276,7 +276,7 @@ There are no standard `options` defined for this `type`. Options are all `propos
 Each `vote_value` pushed to chain should be broken down from their decimal representation to their
 binary representation. `0` will signify all unselected responses, while `1` will signify all selected responses. 
 
-A `vote_value` of `255` represents `Abstain` for consistency across all proposal types (despite 0 being the natural result from the binary conversion)
+A `vote_value` of `0` represents `Abstain`
 
 ## References
 


### PR DESCRIPTION
Currently, any invalid `vote value` is counted as `Abstain`. 
This adds an explicit `vote value`, per proposal type, to represent `Abstain`